### PR TITLE
Fix SOFA Import Degree Handling

### DIFF
--- a/Src/PreProcess_Synthesize_SDM_Binaural.m
+++ b/Src/PreProcess_Synthesize_SDM_Binaural.m
@@ -21,10 +21,6 @@ switch upper(BRIR_data.HRTF_Type)
         HRIR = permute(HRIR, [2, 3, 1]);
 
     case 'SOFA'
-        % Restrict the HRTF directions to az=-180:180 degrees, el=-90:90 degrees
-        HRIR_data.SourcePosition(HRIR_data.SourcePosition(:,1)>pi,1) = ...
-            HRIR_data.SourcePosition(HRIR_data.SourcePosition(:,1)>pi,1) - 2*pi;  
-
         TempSourcePosition(:,1) = deg2rad(HRIR_data.SourcePosition(:,1));
         TempSourcePosition(:,2) = deg2rad(HRIR_data.SourcePosition(:,2));
 


### PR DESCRIPTION
The current SOFA import code results in a right shift of most sources by about 6 degrees and some holes/instability, since the SOFA azimuth in degrees is wrapped by 2*pi as if it were in rad:

![image](https://github.com/facebookresearch/BinauralSDM/assets/32422182/aad2a0ff-7b94-4916-b100-102d19b355b7)

I removed the corresponding lines. Since they are purely re-assigning, there is no impact on the surrounding code. 

While you look at the code, please also evaluate whether the exact same lines are needed for the switch case above. `sph2cart` seems to consist of some simple statements with sines/cosines which should work regardless of angle range. But I don't have an FRL_HRTF file to test that. 