### PR TITLE
Correct DOA Rotation

### DIFF
--- a/Src/Synthesize_SDM_Binaural.m
+++ b/Src/Synthesize_SDM_Binaural.m
@@ -54,7 +54,7 @@ SRIR_data.Diff_BRIR =  SRIR_data.Diff_BRIR(1:N, :);
 
 az_deg = rot(1);
 el_deg = rot(2);
-DOA_cart = (rotz(az_deg) * roty(-el_deg) * SRIR_data.DOA')';
+DOA_cart = (roty(-el_deg) * rotz(-az_deg)  * SRIR_data.DOA')';
 [idx, ~] = knnsearch(BRIR_data.HRTF_cartDir, DOA_cart(1:N, :));
 
 SRIR_data.Spec_BRIR = zeros(length(SRIR_data.P_RIR)+HRIR_len-1, 2);


### PR DESCRIPTION
To my eye, the current DOA rotation to compensate head movement is wrong. 

Please note that while this now works correctly for me, your mileage may vary depending on your coordinate system. I always assume a spherical coordinate system from from the SOFA standard which has a top-pole on the z-axis, measures elevation to xy-plane and has 0° azimuth on the x-axis with mathematically positive azimuth, i.e. positive azimuth from x-axis to y-axis. 

Edit: I just saw there is similar code in `Rotate_DOA.m` where the order seems right but I'm not sure whether you wouldn't want `-el_deg` instead of `el_deg` (line 7). But I'm not using DOA alignment, so I can't quite tell how it all fit together.

See below my notes from the commit message:

Reasoning
---------

Let
r: DOA in room coordinates
h: DOA in head coordinates
Z: Rotation Matrix around z-axis with azimuth angle of head 
Y: Rotation Matrix around y-axis with elevation angle of head

We start with the fact that the DOA in head coordinates can be forward transformed to the room coordinates by
r = ZYh
because the z-direction must only depend on elevation (Y) and not on azimuth (Z). Since the matrix Z does not touch the z-component, this order ensures that.

Invert the formula by multiplying from the left by Y^(-1)Z^(-1): 
h = Y^(-1)Z^(-1)r,
yielding the now implemented formula.

Note that the inverse rotation matrix is either the transpose or the rotation matrix with the negative angle. The negative angle variant is now implemented.

Example
-------

Imagine auralizing a source straight above the listener, i.e. at 90° elevation. The listener is looking upwards 45° and and 90° to the left.

By intuition, the source should be heard from the front at 45° upwards elevation.

Imagine first rotating around the y-axis by -45° (downwards), then around the z-axis by -90° (right). This is wrong, as you would hear the source from the right instead of the front.

Instead, imagine first rotating around the y-axis by -90° (right), then the y-axis by -45° (downwards). In the first step, the location of the source is not changed at all, then it is moved to the front. This is as expected.